### PR TITLE
docs: Add rule - No direct pushes to main branch

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -109,6 +109,7 @@ Captured mistakes and anti-patterns to avoid. These are real issues we've encoun
 | ID | Title | Severity | Description |
 |----|-------|----------|-------------|
 | [LL-GIT-001](lessons-learned/LL-GIT-001-no-ai-branding-commits.md) | No AI Branding in Commits | Low | Including AI tool branding in commit messages without user consent |
+| [LL-GIT-002](lessons-learned/LL-GIT-002-no-direct-main-pushes.md) | No Direct Main Pushes | High | Pushing directly to main branch instead of using PR workflow (even for docs) |
 
 ### Development-Specific
 
@@ -134,6 +135,7 @@ Captured mistakes and anti-patterns to avoid. These are real issues we've encoun
 
 **Version Control:**
 - LL-GIT-001: No AI Branding in Commits
+- LL-GIT-002: No Direct Main Pushes
 
 **To be added:**
 - Translation handling mistakes
@@ -217,9 +219,9 @@ grep -r "type declaration" .agent/ --include="*.md"
 
 ## 📊 Documentation Statistics
 
-**Total Documents**: 10
+**Total Documents**: 11
 - SOPs: 3
-- Lessons Learned: 4
+- Lessons Learned: 5
 - Templates: 3
 - System Docs: 0 (to be added)
 
@@ -230,7 +232,9 @@ grep -r "type declaration" .agent/ --include="*.md"
 - Security: ⚠️ Not yet documented
 
 **Most Recent Updates**:
+- 2025-10-09: Added LL-GIT-002 (No Direct Main Pushes)
 - 2025-10-09: Added LL-VALIDATION-001 (Empty URL Segments)
+- 2025-10-09: Updated DEVELOPMENT_RULES.md with PR-only workflow
 - 2025-10-08: Initial system setup
 - 2025-10-08: Added core development SOPs
 - 2025-10-08: Added first lessons learned

--- a/.agent/lessons-learned/LL-GIT-002-no-direct-main-pushes.md
+++ b/.agent/lessons-learned/LL-GIT-002-no-direct-main-pushes.md
@@ -1,0 +1,44 @@
+# LL-GIT-002: No Direct Pushes to Main Branch
+
+**Tech**: Git | **Severity**: high | **Date**: 2025-10-09
+
+## The Mistake
+Pushed lesson learned documentation directly to `main` branch instead of creating a PR, bypassing code review process even for markdown files.
+
+## Why It's Wrong
+- Bypasses mandatory code review (violates project rule #2)
+- No visibility for team on what changed
+- Can't be easily rolled back if mistake found
+- Sets bad precedent that "small changes" can skip process
+- ALL changes need review - code, docs, config, etc.
+
+## The Fix
+**ALWAYS use PR workflow, even for documentation:**
+
+```bash
+# ❌ Bad - direct to main
+git checkout main
+git add .agent/lessons-learned/LL-XXX.md
+git commit -m "docs: add lesson learned"
+git push origin main  # NEVER DO THIS!
+
+# ✅ Good - via PR
+git checkout -b docs/add-lesson-learned-xxx
+git add .agent/lessons-learned/LL-XXX.md
+git commit -m "docs: Add LL-XXX lesson learned"
+git push origin docs/add-lesson-learned-xxx
+gh pr create --title "docs: Add LL-XXX" --body "..." --base main
+```
+
+## How to Detect
+- Check git history: `git log --oneline --graph main`
+- If you see direct commits without PR merge, that's a red flag
+- Set up branch protection on `main` to prevent this
+
+## Prevention
+- **Enable branch protection** on `main` in GitHub settings
+- Require PR reviews before merging
+- Add rule to DEVELOPMENT_RULES.md (already done)
+- Add reminder to INIT_PROMPT.md (already done)
+- Create git pre-push hook to warn when pushing to main
+- Make it muscle memory: branch → commit → push → PR → review → merge

--- a/PROJECT_FLOW_DOCS/DEVELOPMENT_RULES.md
+++ b/PROJECT_FLOW_DOCS/DEVELOPMENT_RULES.md
@@ -16,3 +16,10 @@
 - Every new function needs corresponding tests
 - Minimum 80% code coverage required
 - Tests must pass before review
+
+### 4. **No Direct Pushes to Main**
+- **NEVER push directly to `main` branch** - even for documentation
+- **ALL changes** must go through Pull Request workflow
+- This includes: code, docs, markdown files, configuration, etc.
+- Only exception: Emergency hotfixes (with team lead approval)
+- Process: Create branch → Make changes → Push branch → Create PR → Review → Merge

--- a/PROJECT_FLOW_DOCS/INIT_PROMPT.md
+++ b/PROJECT_FLOW_DOCS/INIT_PROMPT.md
@@ -29,6 +29,7 @@ WORKFLOW:
 3. For code: TDD (tests first, then implement)
 4. After each checkbox: run tests, request review, mark ✅
 5. Follow stage completion checklist before creating PR
+6. **IMPORTANT:** NEVER push directly to main - ALL changes via PR (even docs)
 
 MY REQUEST:
 [Your instruction here - examples below]


### PR DESCRIPTION
## Documentation Update: Enforce PR-Only Workflow

### Summary
Added development rule and lesson learned to prevent direct pushes to `main` branch. ALL changes must go through PR workflow - including documentation.

### Changes Made

**DEVELOPMENT_RULES.md:**
- Added Rule #4: "No Direct Pushes to Main"
- Applies to: code, docs, markdown, config, everything
- Process: branch → commit → push → PR → review → merge
- Only exception: Emergency hotfixes (with team lead approval)

**INIT_PROMPT.md:**
- Added step 6 to WORKFLOW: "NEVER push directly to main - ALL changes via PR (even docs)"
- Makes rule visible in every session init

**LL-GIT-002: No Direct Main Pushes**
- Documented the mistake I just made (pushed LL-VALIDATION-001 directly to main)
- Severity: High (bypasses mandatory code review)
- Prevention: Branch protection, pre-push hooks, muscle memory

**.agent/README.md:**
- Added LL-GIT-002 to Git-Specific section
- Updated stats: 11 total docs, 5 lessons learned
- Added to recent updates log

### Why This Matters
- Enforces mandatory code review (Rule #2)
- Maintains change visibility for team
- Enables easy rollback if issues found
- No exceptions - "small changes" can have big impact
- Consistency: same process for all changes

### Prevention Checklist
- [x] Rule documented in DEVELOPMENT_RULES.md
- [x] Warning added to INIT_PROMPT.md
- [x] Lesson learned created (LL-GIT-002)
- [ ] TODO: Enable branch protection on `main` in GitHub settings
- [ ] TODO: Add git pre-push hook to warn on main pushes

### Meta Note
This PR itself demonstrates the correct workflow - even for simple documentation changes! 😊

**Next:** Enable branch protection on GitHub to technically prevent direct pushes.